### PR TITLE
Fix syncing

### DIFF
--- a/node/node.py
+++ b/node/node.py
@@ -194,7 +194,8 @@ class Node:
                     is_fork=Option[bool_](is_fork),
                 )
                 await self.send_message(pong)
-                asyncio.create_task(self._sync())
+                if not self.is_syncing:
+                    await self._sync()
 
             case Message.Type.Pong:
                 if self.handshake_state != 1:


### PR DESCRIPTION
If a sync is in progress while a Ping message is being processed, an already requested block will be re-requested.
An additional BlockRequest will lead to an additional BlockResponse that, in turn, will spawn a new _sync call. Eventually, this leads to an increase in the number of BlockRequests with each incoming Ping message, and thus to a decrease of synchronization speed.

This fix resolves the issue.